### PR TITLE
49(SideBoardItem) add Progress component

### DIFF
--- a/src/components/Sidebar/components/SideBarItem/SideBarItem.tsx
+++ b/src/components/Sidebar/components/SideBarItem/SideBarItem.tsx
@@ -1,14 +1,27 @@
 import React, { ReactNode } from "react";
-import "styled-components/macro";
+import styled from "styled-components/macro";
 import { Color } from "variables";
 
 type Props = {
   children: ReactNode;
 };
 
-// const Progress = styled.button`
+const Progress = styled.div`
+  background-color: #24292e;
+  color: white;
+  display: table-cell;
+  font-family: Arial, Helvetica, sans-serif;
+  font-size: 14px;
+  line-height: 21px;
+  height: 25px;
+  width: 200px;
+  padding: 11px 15px;
+  vertical-align: middle;
 
-// `;
+  &:hover {
+    background-color: #0366d6;
+  }
+`;
 
 const SideBarItem = (props: Props) => {
   return (
@@ -17,8 +30,8 @@ const SideBarItem = (props: Props) => {
         background-color: ${Color.White};
       `}
     >
-      {/* <Progress /> */}
       content: {props.children}
+      <Progress>Progress</Progress>
     </div>
   );
 };

--- a/src/components/Sidebar/components/SideBarItem/SideBarItem.tsx
+++ b/src/components/Sidebar/components/SideBarItem/SideBarItem.tsx
@@ -6,6 +6,10 @@ type Props = {
   children: ReactNode;
 };
 
+// const Progress = styled.button`
+
+// `;
+
 const SideBarItem = (props: Props) => {
   return (
     <div
@@ -13,6 +17,7 @@ const SideBarItem = (props: Props) => {
         background-color: ${Color.White};
       `}
     >
+      {/* <Progress /> */}
       content: {props.children}
     </div>
   );


### PR DESCRIPTION
I'm not sure I did this part correctly:
> props (the content of button, in this example "Progress" will be passed via the children prop)

Also, the styles on the images in the issue card did not seem to be accurate?  They seemed like they were zoomed in images given some of the specs listed.  So I did a little bit of math and halved everything, not sure if that is entirely accurate but matches the padding scale more accurately.