### PR TITLE
Fixed sidebar width issue

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -21,7 +21,7 @@ function App() {
       <Container>
         <SideBar
           css={`
-            width: 270px;
+            flex: 0 0 270px;
             height: 100vh;
           `}
           user={HARDCODED_USER}


### PR DESCRIPTION
Changed sidebar's **width** property for **flex: 0 0 270px;** because the sidebar is inside a flexbox. This is equivalent to:

`flex-grow: 0;     /* do not grow   - initial value: 0 */`
`flex-shrink: 0;   /* do not shrink - initial value: 1 */`
`flex-basis: 270px; /* width/height  - initial value: auto */`

cloeses #92

