### PR TITLE
Issue191/replace SidebarItem with MenuItem

### DIFF
--- a/src/components/Menu/Menu.stories.tsx
+++ b/src/components/Menu/Menu.stories.tsx
@@ -1,0 +1,41 @@
+import React from "react";
+import Menu from "./Menu";
+import MenuItem from "./components/MenuItem";
+import Spacer from "../Spacer/Spacer";
+import "styled-components/macro";
+
+export default {
+  title: "Menu",
+};
+
+export const MenuStory = () => (
+  <div>
+    <Menu>
+      <MenuItem>
+        <a href="/">Menu Link 1</a>
+      </MenuItem>
+      <MenuItem>
+        <a href="/">Menu Link 2</a>
+      </MenuItem>
+      <MenuItem>
+        <a href="/">Menu Link 3</a>
+      </MenuItem>
+    </Menu>
+    <Spacer top={4} />
+    <Menu>
+      <MenuItem>
+        <a href="/">Menu Link with Icon 1</a>
+      </MenuItem>
+      <MenuItem>
+        <a href="/">Menu Link with Icon 2</a>
+      </MenuItem>
+      <MenuItem>
+        <a href="/">Menu Link with Icon 3</a>
+      </MenuItem>
+    </Menu>
+  </div>
+);
+
+MenuStory.story = {
+  name: "default",
+};

--- a/src/components/Menu/Menu.tsx
+++ b/src/components/Menu/Menu.tsx
@@ -1,0 +1,16 @@
+import React, { ReactNode } from "react";
+import "styled-components/macro";
+
+type Props = {
+  children: ReactNode;
+};
+
+const Menu = ({ children }: Props) => {
+  return (
+    <nav role="navigation">
+      <ul>{children}</ul>
+    </nav>
+  );
+};
+
+export default Menu;

--- a/src/components/Menu/components/MenuItem.tsx
+++ b/src/components/Menu/components/MenuItem.tsx
@@ -1,0 +1,30 @@
+import React, { ReactNode } from "react";
+import "styled-components/macro";
+import styled from "styled-components/macro";
+import { Color } from "variables";
+
+type Props = {
+  children: ReactNode;
+};
+
+const MenuListItem = styled.li`
+  list-style-type: none;
+
+  a {
+    display: flex;
+    padding: 11px 15px;
+    vertical-align: center;
+    text-decoration: none;
+    transition: color 0.2s ease-in-out, background-color 0.2s ease-in-out;
+  }
+  a:hover {
+    color: ${Color.White};
+    background-color: ${Color.DodgerBlue};
+  }
+`;
+
+const MenuItem = ({ children }: Props) => {
+  return <MenuListItem>{children}</MenuListItem>;
+};
+
+export default MenuItem;

--- a/src/components/Menu/components/MenuItem.tsx
+++ b/src/components/Menu/components/MenuItem.tsx
@@ -9,11 +9,14 @@ type Props = {
 
 const MenuListItem = styled.li`
   list-style-type: none;
+  margin-bottom: 8px;
 
   a {
     display: flex;
     padding: 11px 15px;
     vertical-align: center;
+    color: ${Color.White};
+    font-size: 15px;
     text-decoration: none;
     transition: color 0.2s ease-in-out, background-color 0.2s ease-in-out;
   }

--- a/src/components/Sidebar/SideBar.tsx
+++ b/src/components/Sidebar/SideBar.tsx
@@ -10,7 +10,8 @@ import { User } from "types";
 import SectionHeadline from "./components/SectionHeadline/SectionHeadline";
 import Button from "components/Button/Button";
 import { ReactComponent as plus } from "components/Sidebar/assets/plus.svg";
-import SideBarItem from "./components/SideBarItem/SideBarItem";
+import Menu from "../Menu/Menu";
+import MenuItem from "../Menu/components/MenuItem";
 import Spacer from "../Spacer/Spacer";
 
 type Props = {
@@ -43,12 +44,23 @@ const SideBar = (props: Props) => {
       <TopPart>
         <UserCard user={props.user} />
         <Spacer top={2} />
-        <SideBarItem children={"Afternoon"} />
-        <SideBarItem children={"All Habits"} />
-        <SectionHeadline>More</SectionHeadline>
-        <SideBarItem children={"Progress"} />
-        <SideBarItem children={"Manage Habits"} />
-        <SideBarItem children={"Resources"} />
+        <Menu>
+          <MenuItem>
+            <a href="/">Morning</a>
+          </MenuItem>
+          <MenuItem>
+            <a href="/">All Habits</a>
+          </MenuItem>
+          <MenuItem>
+            <a href="/">Progress</a>
+          </MenuItem>
+          <MenuItem>
+            <a href="/">Manage Habits</a>
+          </MenuItem>
+          <MenuItem>
+            <a href="/">Resources</a>
+          </MenuItem>
+        </Menu>
       </TopPart>
       <BottomPart>
         <Button>

--- a/src/components/Sidebar/SideBar.tsx
+++ b/src/components/Sidebar/SideBar.tsx
@@ -7,7 +7,6 @@ import { Color } from "variables";
 
 import UserCard from "./components/UserCard/UserCard";
 import { User } from "types";
-import SectionHeadline from "./components/SectionHeadline/SectionHeadline";
 import Button from "components/Button/Button";
 import { ReactComponent as plus } from "components/Sidebar/assets/plus.svg";
 import Menu from "../Menu/Menu";


### PR DESCRIPTION
Following on from refactoring the Sidebar.

I've created a Menu and MenuItem component to replace the SideBarItem.

SideBarItem might still come in useful, but the way I see this is we have a menu in the sidebar and a menu in the content section that are very similar so we could use a Menu component for that?

Maybe I am on the wrong train of thought, any feedback would be great!