### PR TITLE
Adds ignore for src/**/*.stories.tsx to codecov.yml

### DIFF
--- a/codecov.yml
+++ b/codecov.yml
@@ -2,6 +2,9 @@ codecov:
   notify:
     require_ci_to_pass: yes
 
+ignore:
+  - **/*.stories.tsx
+
 coverage:
   precision: 5
   round: down


### PR DESCRIPTION
Configures CodeCov to ignore Storybook files. 

This pattern might be completely wrong, feel free to fix and push :)

Closes #221 