### PR TITLE
Removes duplicate styles from MenuItem and moves them to AnchorLink

### DIFF
--- a/src/components/AnchorLink/AnchorLink.tsx
+++ b/src/components/AnchorLink/AnchorLink.tsx
@@ -16,8 +16,9 @@ export const AnchorLink = ({ to, linkColor, children }: Props) => {
       css={`
         display: flex;
         align-items: center;
-        color: ${linkColor};
         padding: 12px 15px;
+        font-size: 15px;
+        color: ${linkColor};
         text-decoration: none;
         transition: color 0.2s ease-in-out, background-color 0.2s ease-in-out;
 

--- a/src/components/Menu/components/MenuItem.tsx
+++ b/src/components/Menu/components/MenuItem.tsx
@@ -1,7 +1,6 @@
 import React, { ReactNode } from "react";
 import "styled-components/macro";
 import styled from "styled-components/macro";
-import { Color } from "variables";
 
 type Props = {
   children: ReactNode;
@@ -10,20 +9,6 @@ type Props = {
 const MenuListItem = styled.li`
   list-style-type: none;
   margin-bottom: 8px;
-
-  a {
-    display: flex;
-    padding: 11px 15px;
-    vertical-align: center;
-    color: ${Color.White};
-    font-size: 15px;
-    text-decoration: none;
-    transition: color 0.2s ease-in-out, background-color 0.2s ease-in-out;
-  }
-  a:hover {
-    color: ${Color.White};
-    background-color: ${Color.DodgerBlue};
-  }
 `;
 
 const MenuItem = ({ children }: Props) => {

--- a/src/components/Sidebar/Sidebar.tsx
+++ b/src/components/Sidebar/Sidebar.tsx
@@ -87,16 +87,18 @@ const Sidebar = (props: Props) => {
             }}
           >
             <ExpandedList direction={true}>
-              <ExpandedListItem>
-                <AnchorLink to={RoutePath.Home}>
-                  <LinkText>Add Area</LinkText>
-                </AnchorLink>
-              </ExpandedListItem>
-              <ExpandedListItem>
-                <AnchorLink to={RoutePath.Home}>
-                  <LinkText>New Habits</LinkText>
-                </AnchorLink>
-              </ExpandedListItem>
+              <Menu>
+                <MenuItem>
+                  <AnchorLink to={RoutePath.Home}>
+                    <LinkText>Add Area</LinkText>
+                  </AnchorLink>
+                </MenuItem>
+                <MenuItem>
+                  <AnchorLink to={RoutePath.Home}>
+                    <LinkText>New Habits</LinkText>
+                  </AnchorLink>
+                </MenuItem>
+              </Menu>
             </ExpandedList>
           </div>
         )}

--- a/src/components/Sidebar/Sidebar.tsx
+++ b/src/components/Sidebar/Sidebar.tsx
@@ -13,9 +13,7 @@ import AnchorLink from "../AnchorLink/AnchorLink";
 import LinkText from "../AnchorLink/components/LinkText";
 import Button from "components/Button/Button";
 import { ReactComponent as plus } from "components/Sidebar/assets/plus.svg";
-import ExpandedList, {
-  ExpandedListItem,
-} from "./components/ExpandedList/ExpandedList";
+import ExpandedList from "./components/ExpandedList/ExpandedList";
 
 type Props = {
   className?: string;

--- a/src/components/Sidebar/components/UserCard/UserCard.test.js
+++ b/src/components/Sidebar/components/UserCard/UserCard.test.js
@@ -77,13 +77,7 @@ it("should redirect to settings", () => {
   };
   render(
     <MemoryRouter>
-      <UserCard
-        user={{
-          firstName: "John",
-          lastName: "Doe",
-          email: "john@doe.com",
-        }}
-      />
+      <UserCard user={testUser} />
       <Route path={RoutePath.Settings}>Only visible when on /settings</Route>
     </MemoryRouter>
   );

--- a/src/components/Sidebar/components/UserCard/UserCard.tsx
+++ b/src/components/Sidebar/components/UserCard/UserCard.tsx
@@ -2,7 +2,7 @@ import React, { useState } from "react";
 import "styled-components/macro";
 import { User } from "types";
 import avatar from "./assets/avatar-image.png";
-import ExpandedList, { ExpandedListItem } from "../ExpandedList/ExpandedList";
+import ExpandedList from "../ExpandedList/ExpandedList";
 import AnchorLink from "../../../AnchorLink/AnchorLink";
 import LinkText from "../../../AnchorLink/components/LinkText";
 import { RoutePath } from "variables";

--- a/src/components/Sidebar/components/UserCard/UserCard.tsx
+++ b/src/components/Sidebar/components/UserCard/UserCard.tsx
@@ -3,7 +3,6 @@ import "styled-components/macro";
 import { User } from "types";
 import avatar from "./assets/avatar-image.png";
 import ExpandedList, { ExpandedListItem } from "../ExpandedList/ExpandedList";
-import { MemoryRouter } from "react-router-dom";
 import AnchorLink from "../../../AnchorLink/AnchorLink";
 import LinkText from "../../../AnchorLink/components/LinkText";
 import { RoutePath } from "variables";
@@ -40,13 +39,9 @@ const UserCard = (props: Props) => {
       </Background>
       {show && (
         <ExpandedList>
-          <ExpandedListItem>
-            <MemoryRouter>
-              <AnchorLink to={RoutePath.Settings}>
-                <LinkText>Profile & Settings</LinkText>
-              </AnchorLink>
-            </MemoryRouter>
-          </ExpandedListItem>
+          <AnchorLink to={RoutePath.Settings}>
+            <LinkText>Profile & Settings</LinkText>
+          </AnchorLink>
         </ExpandedList>
       )}
     </div>


### PR DESCRIPTION
Closes #231 

Tidied this up.

Cannot figure out where, why or how these _css attributes come from on the rendered AnchorLink...

```<a role="menuitem" _css="rgb(0,0,0)" _css2="rgb(255,255,255)" _css3="rgb(67, 124, 255)" class="AnchorLink___StyledLink-sc-1cirq1q-0 dYCXgq" href="/settings"><span>Profile &amp; Settings</span></a>```